### PR TITLE
Dictionary crash when loading plugin

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -109,7 +109,18 @@ namespace Oxide
                 {
                     var value = table[key];
                     if (value is LuaFunction)
-                        functionmap.Add((string)key, value as LuaFunction);
+                    {
+                        try
+                        {
+                            
+                            functionmap.Add((string)key, value as LuaFunction);
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Error(string.Format("Failed to map function {0} in {1} table.Keys", (string)key, Name));
+                        }
+                    }
+                    
                 }
             }
 
@@ -124,7 +135,17 @@ namespace Oxide
                     {
                         var value = basetable[key];
                         if (value is LuaFunction)
-                            functionmap.Add((string)key, value as LuaFunction);
+                        {
+                            try
+                            {
+                                
+                                functionmap.Add((string)key, value as LuaFunction);
+                            }
+                            catch (Exception e)
+                            {
+                                Logger.Error(string.Format("Failed to map function {0} in {1} metatable", (string)key, Name));
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Stops http://forum.rustoxide.com/threads/an-element-with-the-same-key-already-exists-in-the-dictionary.2073/ error from not loading plugin.

Issue is with trying to use hooks that are in baseplugin.lua
