### PR TITLE
Correct version, add rustoxide.com ResourceId

### DIFF
--- a/Plugins/oxidecore.lua
+++ b/Plugins/oxidecore.lua
@@ -7,7 +7,8 @@
 PLUGIN.Title = "Oxide Core"
 PLUGIN.Description = "Abstracts many hooks into a much improved API for other plugins to use"
 PLUGIN.Author = "thomasfn"
-PLUGIN.Version = "1.16"
+PLUGIN.Version = "1.17.3"
+PLUGIN.ResourceId = "3"
 
 -- Load some enums
 typesystem.LoadEnum( Rust.NetError, "NetError" )
@@ -16,7 +17,7 @@ typesystem.LoadEnum( System.Reflection.BindingFlags, "BindingFlags" )
 typesystem.LoadEnum( Rust.LifeStatus, "LifeStatus" )
 
 -- Oxide version
-PLUGIN.OxideVersion = "Oxide 1.16"
+PLUGIN.OxideVersion = "Oxide " .. PLUGIN.Version
 PLUGIN.RustProtocolVersion = 0x42d
 
 -- Get some other functions


### PR DESCRIPTION
- ResourceId is used for update checking with plugins such as Updater
  http://forum.rustoxide.com/resources/updater.380/
