### PR TITLE
Added character escaping on display names

### DIFF
--- a/Lua STL/rust.lua
+++ b/Lua STL/rust.lua
@@ -57,7 +57,8 @@ function rust.FindNetUsersByName( name )
 	local tmp = {}
 	for i=1, #allnetusers do
 		local netuser = allnetusers[i]
-		if (netuser.user.Displayname:match( name )) then
+		local escapedName = string.gsub(netuser.user.Displayname, "[%-?*+%[%]%(%)]", "%%%0")
+		if (netuser.user.Displayname:match( escapedName )) then
 			tmp[ #tmp + 1 ] = netuser
 		end
 	end


### PR DESCRIPTION
This is originally from @AdamChandler, just splitting his original PR for him. https://github.com/RustOxide/Oxide/pull/24

Some users on the forums have been experiencing problems with the function: rust.FindNetUsersByName
It would not return the correct user if the user had special characters in their name.
This will escape the special characters for pattern matching which were causing problems.
Reports:
http://forum.rustoxide.com/threads/rust-findnetusersbyname-bug-with-brackets.2279/#post-28346
http://forum.rustoxide.com/threads/passing-netuser-displayname-to-another-plugin.2404/#post-30377
