### PR TITLE
Added the ability to load a plugin without a restart

### DIFF
--- a/Lua STL/plugins.lua
+++ b/Lua STL/plugins.lua
@@ -14,6 +14,10 @@ function plugins.Reload( name )
 	return cs.reloadplugin( name )
 end
 
+function plugins.Load( name )
+	print("plugins.Load")
+	return cs.loadplugin( name )
+end
 api = {}
 local apibindings = {}
 function api.Bind( plugin, apiname )

--- a/Main.cs
+++ b/Main.cs
@@ -164,6 +164,7 @@ namespace Oxide
             RegisterFunction("cs.readpropertyandsetonarray", "lua_ReadPropertyAndSetOnArray");
             RegisterFunction("cs.readfieldandsetonarray", "lua_ReadFieldAndSetOnArray");
             RegisterFunction("cs.reloadplugin", "lua_ReloadPlugin");
+            RegisterFunction("cs.loadplugin", "lua_LoadPlugin");
             RegisterFunction("cs.getdatafile", "lua_GetDatafile");
             RegisterFunction("cs.getdatafilelist", "lua_GetDatafileList"); // LMP
             RegisterFunction("cs.removedatafile", "lua_RemoveDatafile"); // LMP
@@ -467,11 +468,17 @@ namespace Oxide
         }
         private bool lua_LoadPlugin(string name)
         {
+			Logger.Message("lua_LoadPlugin: " + name );
             Plugin oldplugin = pluginmanager[name];
             if (oldplugin != null) return false;
             Plugin p = new Plugin(lua);
-            if (!p.Load(oldplugin.Filename)) return false;
+            if (!p.Load(string.Format("{0}\\{1}.lua", GetPath("plugins"),name))) return false;
             pluginmanager.AddPlugin(p);
+            p.Call("Init", null);
+            p.Call("PostInit", null);
+            p.Call("ServerStart", null);
+            p.Call("OnDatablocksLoaded", null);
+            p.Call("OnServerInitialized", null);
             return true;
         }
 

--- a/Plugins/oxidecore.lua
+++ b/Plugins/oxidecore.lua
@@ -32,6 +32,7 @@ function PLUGIN:Init()
 	-- Add console commands
 	self:AddCommand( "oxide", "reloadcore", self.ccmdReload )
 	self:AddCommand( "oxide", "reload", self.ccmdReloadPlugin )
+	self:AddCommand( "oxide", "load", self.ccmdLoadPlugin )
 	self:AddCommand( "chat", "say", self.ccmdChat )
 	
 	-- Add chat commands
@@ -432,6 +433,19 @@ function PLUGIN:ccmdReloadPlugin( arg )
 	return true
 end
 
+-- *******************************************
+-- PLUGIN:ccmdLoadPlugin()
+-- Called when the user executes "oxide.reload"
+-- *******************************************
+function PLUGIN:ccmdLoadPlugin( arg )
+	local user = arg.argUser
+	if (user and not user:CanAdmin()) then return true end
+	local name = arg:GetString( 0, "text" )
+	print( "Loading oxide plugin '" .. name .. "'..." )
+	local result = plugins.Load( name )
+	if (not result) then print( "Loading failed." ) end
+	return true
+end
 -- *******************************************
 -- PLUGIN:cmdMod()
 -- Called when the user executes the "/mod" chat command


### PR DESCRIPTION
This is originally from @AdamChandler, just splitting his original PR for him. https://github.com/RustOxide/Oxide/pull/24

Can now use oxide.load filename to load a plugin without restarting the server.
