### PR TITLE
Native queuing for Web Request

### DIFF
--- a/AsyncWebRequest.cs
+++ b/AsyncWebRequest.cs
@@ -52,6 +52,8 @@ namespace Oxide
                 //Main.Log("Creating request...");
                 request = WebRequest.Create(url);
                 request.Credentials = CredentialCache.DefaultCredentials;
+                //30 Second timeout instead of 2 minutes before.
+                request.Timeout = 30000;
                 //Main.Log("Waiting for response...");
 
                 if (this.ispost == true && this.postdata != null)
@@ -96,7 +98,11 @@ namespace Oxide
                 ResponseCode = -1;
                 Logger.Error(ex.ToString());
             }
-            Complete = true;
+            finally
+            {
+                Complete = true;
+            }
+            
         }
 
         /// <summary>


### PR DESCRIPTION
This is originally from @AdamChandler, just splitting his original PR for him. https://github.com/RustOxide/Oxide/pull/24

"As more and more plugins use web request the hard coded limit of three web request became a barrier. I kept the rule were only three request can be active but allowed for other request to queue and wait to be sent."
