### PR TITLE
Config - Added JSON-Formatting Optional Parameters

### DIFF
--- a/Lua STL/config.lua
+++ b/Lua STL/config.lua
@@ -26,10 +26,9 @@ function config.Save( name, options )
 	local tbl = configfiles[ name ]
 	if (not tbl) then return false end
 	local df = cs.getdatafile( "cfg_" .. name )
-	if (type(options) ~= "table") then
-		options = false
-	end
+	if (type(options) ~= "table") then options = false end
 	df:SetText( json.encode( tbl, options or { indent = true } ) )
 	df:Save()
 	return true
 end
+`


### PR DESCRIPTION
- Allows the use of keyorder and other such options

I don't know if this is the correct (safe/non-error-prone) way to do this, but just putting the suggestion in there.  Maybe it needs a sanity check for 'options' being a table or something?
